### PR TITLE
Added query selector to make constructing image from canvas easier

### DIFF
--- a/src/sd-texture.js
+++ b/src/sd-texture.js
@@ -131,6 +131,8 @@ export default class Texture extends HTMLElement {
       this._setupVideo();
     } else if (isImage(this.src)) {
       this._setupImage();
+    } else {
+      this._setupCanvasImage(this.src)
     }
   }
 
@@ -180,6 +182,14 @@ export default class Texture extends HTMLElement {
         PIXEL
       );
     }
+  }
+
+  _setupCanvasImage(id) {
+    const canvas = document.querySelector(id)
+    if (canvas) {
+      this.src = canvas.toDataURL()
+    }
+    this._setupImage()
   }
 
   _setupImage() {


### PR DESCRIPTION
Hey! Absolutely love what you've done with this component! 

I wanted to make importing a texture from a local canvas easier, so I added a fallback to `init` to try to find an element that matches the CSS selector given in `src` and create an image from the data URL of that element.

So, with this PR, importing a canvas texture to a shader looks like this:

```
<canvas id="my-canvas" />

<shader-doodle>
  <sd-texture src="#my-canvas" />

  <script type="x-shader/x-fragment">
    uniform sampler2D u_texture_0;

    void main() {
      // ...normal fragment shader, with canvas available as u_texture_0
    }
  </script>
</shader-doodle>
```

Just wanted to send this your way - thanks for the fantastic work!