### PR TITLE
bugfix: add texture size check before update

### DIFF
--- a/src/webgl/Texture.js
+++ b/src/webgl/Texture.js
@@ -99,6 +99,14 @@ export default function Texture(gl, textureUnit, optsParam = {}) {
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
 
     if (pixels) {
+      if (pixels.width === 0 || pixels.height === 0) {
+        console.warn(
+          `Texture size is invalid ${pixels.width} x ${pixels.height}. Update is skipped;`
+        );
+
+        return;
+      }
+
       checkPow2();
     }
 


### PR DESCRIPTION
[Issue-28](https://github.com/halvves/shader-doodle/issues/28)

The texture was trying to update even if it's new size is invalid (has zero width or height), what leads to a WebGL error.
Because we don't actualy need to update the texture in such case, I added a short check with a warning message and early exit.