### PR TITLE
Add custom uniforms + Add force canvas size settings + Fix re-create <shader-doodle>

### DIFF
--- a/src/sd-node.js
+++ b/src/sd-node.js
@@ -71,6 +71,32 @@ class SDNodeElement extends SDBaseElement {
     this.setAttribute('vertices', JSON.stringify(v));
   }
 
+  get forcedHeight() {
+    let h = this.getAttribute('data-forced-height');
+    if (!h) return -1;
+    return parseInt(h);
+  }
+
+  set forcedHeight(h) {
+    let height = parseInt(h);
+    if (!h || !Number.isInteger(height)) return;
+
+    this.setAttribute('data-forced-height', h);
+  }
+
+  get forcedWidth() {
+    let h = this.getAttribute('data-forced-width');
+    if (!h) return -1;
+    return parseInt(h);
+  }
+
+  set forcedWidth(h) {
+    let width = parseInt(h);
+    if (!h || !Number.isInteger(width)) return;
+
+    this.setAttribute('data-forced-width', h);
+  }
+
   async init(parentProgram) {
     if (parentProgram && !this.name) {
       this.name = `${UNNAMED_NODE_PREFIX}${unnamedNodeIndex++}`;

--- a/src/sd-texture.js
+++ b/src/sd-texture.js
@@ -41,7 +41,8 @@ class TextureElement extends SDBaseElement {
 
   disconnectedCallback() {
     this.program.removeTexture(this.texture);
-    this.texture.dispose();
+    // Dispose doesn't seem to exist on this object. A TODO?
+    if (typeof this.texture.dispose === 'function') this.texture.dispose();
   }
 
   get forceUpdate() {

--- a/src/sd-uniform.js
+++ b/src/sd-uniform.js
@@ -1,0 +1,49 @@
+import SDBaseElement from './sd-base.js';
+
+class SDUniformElement extends SDBaseElement {
+  disconnectedCallback() {}
+
+  get x() {
+    return parseFloat(this.getAttribute('x'));
+  }
+
+  set x(newX) {
+    if (newX != null) this.setAttribute('x', newX);
+    else this.removeAttribute('x');
+  }
+
+  get type() {
+    return this.getAttribute('type');
+  }
+
+  set type(newType) {
+    if (newType != null) this.setAttribute('type', newType);
+    else this.removeAttribute('type');
+  }
+
+  static get observedAttributes() {
+    return ['x'];
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    switch (name) {
+      case 'x':
+        if (newValue != null) this.renderer.setUniform(this.name, newValue);
+        break;
+    }
+  }
+
+  init(program) {
+    if (!this.name) {
+      console.warn('sd-uniform created without a name.');
+      return;
+    }
+
+    this.program = program;
+    this.renderer.addUniform(this.name, this.x, this.type);
+  }
+}
+
+if (!customElements.get('sd-uniform')) {
+  customElements.define('sd-uniform', SDUniformElement);
+}

--- a/src/sd-uniform.js
+++ b/src/sd-uniform.js
@@ -7,9 +7,49 @@ class SDUniformElement extends SDBaseElement {
     return parseFloat(this.getAttribute('x'));
   }
 
-  set x(newX) {
-    if (newX != null) this.setAttribute('x', newX);
+  set x(newx) {
+    if (newx != null) this.setAttribute('x', newx);
     else this.removeAttribute('x');
+  }
+
+  get y() {
+    return parseFloat(this.getAttribute('y'));
+  }
+
+  set y(newy) {
+    if (newy != null) this.setAttribute('y', newy);
+    else this.removeAttribute('y');
+  }
+
+  get z() {
+    return parseFloat(this.getAttribute('z'));
+  }
+
+  set z(newz) {
+    if (newz != null) this.setAttribute('z', newz);
+    else this.removeAttribute('z');
+  }
+
+  get w() {
+    return parseFloat(this.getAttribute('w'));
+  }
+
+  set w(neww) {
+    if (neww != null) this.setAttribute('w', neww);
+    else this.removeAttribute('w');
+  }
+
+  getValue() {
+    switch (this.type) {
+      case 'vec2':
+        return [this.x, this.y];
+      case 'vec3':
+        return [this.x, this.y, this.z];
+      case 'vec4':
+        return [this.x, this.y, this.z, this.w];
+      default:
+        return this.x;
+    }
   }
 
   get type() {
@@ -22,13 +62,17 @@ class SDUniformElement extends SDBaseElement {
   }
 
   static get observedAttributes() {
-    return ['x'];
+    return ['x', 'y', 'z', 'w'];
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
     switch (name) {
       case 'x':
-        if (newValue != null) this.renderer.setUniform(this.name, newValue);
+      case 'y':
+      case 'z':
+      case 'w':
+        if (newValue != null)
+          this.renderer.setUniform(this.name, this.getValue());
         break;
     }
   }
@@ -40,7 +84,7 @@ class SDUniformElement extends SDBaseElement {
     }
 
     this.program = program;
-    this.renderer.addUniform(this.name, this.x, this.type);
+    this.renderer.addUniform(this.name, this.getValue(), this.type);
   }
 }
 

--- a/src/shader-doodle.js
+++ b/src/shader-doodle.js
@@ -4,6 +4,7 @@ import './sd-audio.js';
 import './sd-texture.js';
 
 import Surface from './webgl/Surface.js';
+import Renderer from './webgl/Renderer.js';
 
 class ShaderDoodleElement extends SDNodeElement {
   constructor() {
@@ -29,6 +30,7 @@ class ShaderDoodleElement extends SDNodeElement {
   }
 
   async init() {
+    Renderer.resetSingleton();
     this.shadow.innerHTML = Template.render();
     const canvas = Template.map(this.shadow).canvas;
 

--- a/src/shader-doodle.js
+++ b/src/shader-doodle.js
@@ -34,7 +34,7 @@ class ShaderDoodleElement extends SDNodeElement {
 
     await super.init();
 
-    this.surface = Surface(canvas, this.program);
+    this.surface = Surface(canvas, this.program, this);
     this.renderer.addSurface(this.surface);
   }
 }

--- a/src/shader-doodle.js
+++ b/src/shader-doodle.js
@@ -2,6 +2,7 @@ import Template from './template.js';
 import SDNodeElement from './sd-node.js';
 import './sd-audio.js';
 import './sd-texture.js';
+import './sd-uniform.js';
 
 import Surface from './webgl/Surface.js';
 import Renderer from './webgl/Renderer.js';

--- a/src/webgl/Program.js
+++ b/src/webgl/Program.js
@@ -177,7 +177,9 @@ export default function Program(gl, vs, fs, vertices, shadertoy = false) {
   }
 
   function dispose() {
-    textures.forEach(t => t.dispose());
+    textures.forEach(t => {
+      if (typeof t.dispose === 'function') t.dispose();
+    });
     textures.clear();
     gl.deleteProgram(program);
   }

--- a/src/webgl/Renderer.js
+++ b/src/webgl/Renderer.js
@@ -142,7 +142,7 @@ Renderer.singleton = function() {
 };
 
 Renderer.resetSingleton = function() {
-  singletonRenderer.dispose();
+  if (singletonRenderer) singletonRenderer.dispose();
   singletonRenderer = Renderer();
 };
 

--- a/src/webgl/Renderer.js
+++ b/src/webgl/Renderer.js
@@ -25,7 +25,7 @@ function Renderer() {
   let animationFrame;
   let lastTime;
 
-  const surfaces = new Set();
+  let surfaces = new Set();
 
   const ustate = cheapClone(GLOBAL_UNIFORMS);
   /* TODO UNIFORM*/

--- a/src/webgl/Renderer.js
+++ b/src/webgl/Renderer.js
@@ -28,6 +28,7 @@ function Renderer() {
   const surfaces = new Set();
 
   const ustate = cheapClone(GLOBAL_UNIFORMS);
+  /* TODO UNIFORM*/
 
   const extensions = Extensions(gl);
   extensions.get('OES_texture_float');
@@ -106,6 +107,24 @@ function Renderer() {
     surfaces.delete(surface);
   }
 
+  function addUniform(name, value, type) {
+    ustate.push({
+      name,
+      value,
+      type,
+      toyname: name,
+    });
+  }
+
+  function setUniform(name, value) {
+    for (let i = 0; i < ustate.length; i++) {
+      if (ustate[i].name === name) {
+        ustate[i].value = value;
+        break;
+      }
+    }
+  }
+
   function dispose() {
     surfaces.forEach(s => s.dispose());
     surfaces.clear();
@@ -128,6 +147,8 @@ function Renderer() {
     },
     addSurface,
     removeSurface,
+    addUniform,
+    setUniform,
     dispose,
   });
 }

--- a/src/webgl/Surface.js
+++ b/src/webgl/Surface.js
@@ -5,7 +5,7 @@ import getMouseOrTouch from '../utils/getMouseOrTouch.js';
 
 import { MOUSE, MOUSEDRAG, RESOLUTION, SURFACE_UNIFORMS } from './constants.js';
 
-function Surface(element, program) {
+function Surface(element, program, sdNode) {
   const canvas =
     element instanceof HTMLCanvasElement
       ? element
@@ -74,15 +74,24 @@ function Surface(element, program) {
       newRect.right - newRect.width <=
         (window.innerWidth || document.documentElement.clientWidth);
 
-    if (newRect.width !== rect.width) {
-      canvas.width = ustate[RESOLUTION].value[0] = newRect.width;
+    const h =
+      sdNode.forcedHeight && sdNode.forcedHeight > 0
+        ? sdNode.forcedHeight
+        : newRect.height;
+    const w =
+      sdNode.forcedWidth && sdNode.forcedWidth > 0
+        ? sdNode.forcedWidth
+        : newRect.width;
+
+    if (w !== rect.width) {
+      canvas.width = ustate[RESOLUTION].value[0] = w;
     }
 
-    if (newRect.height !== rect.height) {
-      canvas.height = ustate[RESOLUTION].value[1] = newRect.height;
+    if (h !== rect.height) {
+      canvas.height = ustate[RESOLUTION].value[1] = h;
     }
 
-    rect = newRect;
+    rect = { width: canvas.width, height: canvas.height };
   }
 
   function render(


### PR DESCRIPTION
Hi, 

I've used shader-doodle for a project and needed to customize it a bit. I haven't really made the changes with a PR in mind, but I thought you or others could be interested. Feel free to reject the PR or ask for seperate ones :) 

### Changes:

**A new `<sd-uniform/>` component** that supports floats and vecX with x, y, z and w. 
Values are updated via HTML attributes, which might not be the fastest, but it looked cleaner than properties or functions to me and CPUs usually aren't the limiting factor for shader projects.

Example usage in React: 
```jsx
<sd-uniform name="axis2" x={parameters.axis2} type="float" />
```
and in the shader:
```glsl
uniform float axis2;
```

**Add `data-forced-height` and `data-forced-width` attributes to `<shader-doodle/>`**
I needed to resize the canvas to keep a specific aspect ratio and a specific resolution (because generated visuals are saved afterwards in my project). I used the data- prefix to clear validation.

**Fix re-create `<shader-doodle/>`**
I needed to destroy and recreate a shader-doodle component and that gave me errors, so I fixed them however I could, but I don't think shader-doodle is made for that yet (For example, I think that textures aren't being disposed of for now).