### PR TITLE
Adding blending for transparent images

### DIFF
--- a/src/webgl/Renderer.js
+++ b/src/webgl/Renderer.js
@@ -18,6 +18,9 @@ function Renderer() {
   const wa = new (window.AudioContext || window.webkitAudioContext)();
   const audioCtxResume = new AudioContextResume(wa);
   wa.onStart = audioCtxResume.onStart;
+  
+  gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+  gl.enable(gl.BLEND);
 
   let width = 0;
   let height = 0;


### PR DESCRIPTION
This commit adds blending support for transparent PNGs as described [here](https://community.khronos.org/t/texturing-a-png-so-alpha-channel-part-is-transparent/2413/4). I'm not sure if there's any reason not to do this every canvas, but if there is I could make an attribute required (`blending` or `enable-blending`, for example). Let me know if there's anything I'm missing - thanks!