### PR TITLE
move force h/w to basic h/w attribs on shader-doodle component

### DIFF
--- a/demo/react.html
+++ b/demo/react.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Shader Doodle Demo</title>
+    <script
+      crossorigin
+      src="https://unpkg.com/react@16/umd/react.development.js"
+    ></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"
+    ></script>
+    <script type="module" src="../src/shader-doodle.js"></script>
+    <style>
+      shader-doodle {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script>
+      const fs = `
+      uniform sampler2D u_texture0;
+
+      void main() {
+        vec2 uv = gl_FragCoord.xy / u_resolution.xy;
+        float distortion = sin(uv.y * 50.0 + u_time * 5.0) * 0.01;
+        vec4 texture = texture2D(u_texture0, vec2(
+          uv.x + distortion * u_mouse.x / 100.,
+          uv.y + distortion * u_mouse.y / 100.
+        ));
+
+        gl_FragColor = texture;
+      }`;
+
+      const App = () => {
+        const [width, setWidth] = React.useState(500);
+        const [imgSrc, setImgSrc] = React.useState('image.jpg');
+
+        return React.createElement(React.Fragment, {}, [
+          React.createElement(
+            'shader-doodle',
+            { key: imgSrc, height: 300, width },
+            [
+              React.createElement('sd-texture', {
+                key: 'texture',
+                src: imgSrc,
+              }),
+              React.createElement(
+                'script',
+                { key: 'main-fs', type: 'x-shader/x-fragment' },
+                fs
+              ),
+            ]
+          ),
+          React.createElement('input', {
+            key: 'width-input',
+            onChange: e => setWidth(parseInt(e.currentTarget.value)),
+            value: width,
+          }),
+          React.createElement(
+            'select',
+            {
+              key: 'img-select',
+              name: 'img',
+              onChange: e => setImgSrc(e.currentTarget.value),
+              value: imgSrc,
+            },
+            [
+              React.createElement(
+                'option',
+                { key: 'image.jpg', value: 'image.jpg' },
+                'image.jpg'
+              ),
+              React.createElement(
+                'option',
+                { key: 'noise.png', value: 'noise.png' },
+                'noise.png'
+              ),
+            ]
+          ),
+        ]);
+      };
+
+      ReactDOM.render(
+        React.createElement(App),
+        document.getElementById('root')
+      );
+    </script>
+  </body>
+</html>

--- a/src/sd-node.js
+++ b/src/sd-node.js
@@ -71,32 +71,6 @@ class SDNodeElement extends SDBaseElement {
     this.setAttribute('vertices', JSON.stringify(v));
   }
 
-  get forcedHeight() {
-    let h = this.getAttribute('data-forced-height');
-    if (!h) return -1;
-    return parseInt(h);
-  }
-
-  set forcedHeight(h) {
-    let height = parseInt(h);
-    if (!h || !Number.isInteger(height)) return;
-
-    this.setAttribute('data-forced-height', h);
-  }
-
-  get forcedWidth() {
-    let h = this.getAttribute('data-forced-width');
-    if (!h) return -1;
-    return parseInt(h);
-  }
-
-  set forcedWidth(h) {
-    let width = parseInt(h);
-    if (!h || !Number.isInteger(width)) return;
-
-    this.setAttribute('data-forced-width', h);
-  }
-
   async init(parentProgram) {
     if (parentProgram && !this.name) {
       this.name = `${UNNAMED_NODE_PREFIX}${unnamedNodeIndex++}`;

--- a/src/sd-texture.js
+++ b/src/sd-texture.js
@@ -41,8 +41,7 @@ class TextureElement extends SDBaseElement {
 
   disconnectedCallback() {
     this.program.removeTexture(this.texture);
-    // Dispose doesn't seem to exist on this object. A TODO?
-    if (typeof this.texture.dispose === 'function') this.texture.dispose();
+    this.texture.dispose();
   }
 
   get forceUpdate() {

--- a/src/shader-doodle.js
+++ b/src/shader-doodle.js
@@ -17,6 +17,9 @@ class ShaderDoodleElement extends SDNodeElement {
   }
 
   connectedCallback() {
+    this.shadow.innerHTML = Template.render(this.width, this.height);
+    this.canvas = Template.map(this.shadow).canvas;
+
     setTimeout(() => {
       try {
         this.init();
@@ -69,9 +72,6 @@ class ShaderDoodleElement extends SDNodeElement {
   }
 
   async init() {
-    this.shadow.innerHTML = Template.render(this.width, this.height);
-    this.canvas = Template.map(this.shadow).canvas;
-
     await super.init();
 
     this.surface = Surface(this);

--- a/src/shader-doodle.js
+++ b/src/shader-doodle.js
@@ -7,6 +7,10 @@ import './sd-uniform.js';
 import Surface from './webgl/Surface.js';
 
 class ShaderDoodleElement extends SDNodeElement {
+  static get observedAttributes() {
+    return ['height', 'width'];
+  }
+
   constructor() {
     super();
     this.shadow = this.attachShadow({ mode: 'open' });
@@ -27,6 +31,15 @@ class ShaderDoodleElement extends SDNodeElement {
     this.renderer.removeSurface(this.surface);
     this.surface.dispose();
     this.surface = undefined;
+  }
+
+  attributeChangedCallback(name) {
+    if (name === 'height' || name === 'width') {
+      const val = this[name];
+      this.shadow.styleSheets[0].cssRules[0].style[name] = Number.isInteger(val)
+        ? `${val}px`
+        : '250px';
+    }
   }
 
   get height() {
@@ -56,7 +69,7 @@ class ShaderDoodleElement extends SDNodeElement {
   }
 
   async init() {
-    this.shadow.innerHTML = Template.render();
+    this.shadow.innerHTML = Template.render(this.width, this.height);
     this.canvas = Template.map(this.shadow).canvas;
 
     await super.init();

--- a/src/shader-doodle.js
+++ b/src/shader-doodle.js
@@ -5,7 +5,6 @@ import './sd-texture.js';
 import './sd-uniform.js';
 
 import Surface from './webgl/Surface.js';
-import Renderer from './webgl/Renderer.js';
 
 class ShaderDoodleElement extends SDNodeElement {
   constructor() {
@@ -30,14 +29,39 @@ class ShaderDoodleElement extends SDNodeElement {
     this.surface = undefined;
   }
 
+  get height() {
+    const height = parseInt(this.getAttribute('height'));
+
+    return Number.isInteger(height) ? height : undefined;
+  }
+
+  set height(h) {
+    const height = parseInt(h);
+    if (!Number.isInteger(height)) return;
+
+    this.setAttribute('height', h);
+  }
+
+  get width() {
+    const width = parseInt(this.getAttribute('width'));
+
+    return Number.isInteger(width) ? width : undefined;
+  }
+
+  set width(w) {
+    const width = parseInt(w);
+    if (!Number.isInteger(width)) return;
+
+    this.setAttribute('width', width);
+  }
+
   async init() {
-    Renderer.resetSingleton();
     this.shadow.innerHTML = Template.render();
-    const canvas = Template.map(this.shadow).canvas;
+    this.canvas = Template.map(this.shadow).canvas;
 
     await super.init();
 
-    this.surface = Surface(canvas, this.program, this);
+    this.surface = Surface(this);
     this.renderer.addSurface(this.surface);
   }
 }

--- a/src/shader-doodle.js
+++ b/src/shader-doodle.js
@@ -14,12 +14,11 @@ class ShaderDoodleElement extends SDNodeElement {
   constructor() {
     super();
     this.shadow = this.attachShadow({ mode: 'open' });
+    this.shadow.innerHTML = Template.render(this.width, this.height);
+    this.canvas = Template.map(this.shadow).canvas;
   }
 
   connectedCallback() {
-    this.shadow.innerHTML = Template.render(this.width, this.height);
-    this.canvas = Template.map(this.shadow).canvas;
-
     setTimeout(() => {
       try {
         this.init();

--- a/src/shader-doodle.js
+++ b/src/shader-doodle.js
@@ -14,11 +14,12 @@ class ShaderDoodleElement extends SDNodeElement {
   constructor() {
     super();
     this.shadow = this.attachShadow({ mode: 'open' });
-    this.shadow.innerHTML = Template.render(this.width, this.height);
-    this.canvas = Template.map(this.shadow).canvas;
   }
 
   connectedCallback() {
+    this.shadow.innerHTML = Template.render(this.width, this.height);
+    this.canvas = Template.map(this.shadow).canvas;
+
     setTimeout(() => {
       try {
         this.init();
@@ -36,9 +37,10 @@ class ShaderDoodleElement extends SDNodeElement {
   }
 
   attributeChangedCallback(name) {
-    if (name === 'height' || name === 'width') {
+    const styles = this.shadow.styleSheets;
+    if ((name === 'height' || name === 'width') && styles.length > 0) {
       const val = this[name];
-      this.shadow.styleSheets[0].cssRules[0].style[name] = Number.isInteger(val)
+      styles[0].cssRules[0].style[name] = Number.isInteger(val)
         ? `${val}px`
         : '250px';
     }

--- a/src/template.js
+++ b/src/template.js
@@ -1,6 +1,6 @@
 export default {
-  render() {
-    return `${this.css()}
+  render(w, h) {
+    return `${this.css(w, h)}
             ${this.html()}`;
   },
 
@@ -14,13 +14,13 @@ export default {
     return `<canvas></canvas>`;
   },
 
-  css() {
+  css(w, h) {
     return `<style>
       :host {
         position: relative;
         display: inline-block;
-        width: 250px;
-        height: 250px;
+        width: ${w || 250}px;
+        height: ${h || 250}px;
       }
       :host > canvas {
         position: absolute;
@@ -29,7 +29,7 @@ export default {
         height: 100%;
         width: 100%;
         border-radius: inherit;
-       }
+      }
     </style>`;
   },
 };

--- a/src/webgl/AudioTexture.js
+++ b/src/webgl/AudioTexture.js
@@ -140,6 +140,10 @@ function AudioTexture(
     }
   }
 
+  function dispose() {
+    texture.dispose();
+  }
+
   // TODO: mic support
   /* if (mic) {
     setupMic();
@@ -154,6 +158,7 @@ function AudioTexture(
   }
 
   return {
+    dispose,
     update,
   };
 }

--- a/src/webgl/GeneralTexture.js
+++ b/src/webgl/GeneralTexture.js
@@ -190,6 +190,10 @@ export default function GeneralTexture(
     }
   }
 
+  function dispose() {
+    texture.dispose();
+  }
+
   // init
   if (webcam) {
     setupCamera();
@@ -202,6 +206,7 @@ export default function GeneralTexture(
   }
 
   return {
+    dispose,
     update,
   };
 }

--- a/src/webgl/Program.js
+++ b/src/webgl/Program.js
@@ -177,9 +177,7 @@ export default function Program(gl, vs, fs, vertices, shadertoy = false) {
   }
 
   function dispose() {
-    textures.forEach(t => {
-      if (typeof t.dispose === 'function') t.dispose();
-    });
+    textures.forEach(t => t.dispose());
     textures.clear();
     gl.deleteProgram(program);
   }

--- a/src/webgl/Renderer.js
+++ b/src/webgl/Renderer.js
@@ -18,7 +18,7 @@ function Renderer() {
   const wa = new (window.AudioContext || window.webkitAudioContext)();
   const audioCtxResume = new AudioContextResume(wa);
   wa.onStart = audioCtxResume.onStart;
-  
+
   gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
   gl.enable(gl.BLEND);
 

--- a/src/webgl/Renderer.js
+++ b/src/webgl/Renderer.js
@@ -78,6 +78,7 @@ function Renderer() {
 
   function render(timestamp) {
     if (!surfaces.size) {
+      animationFrame = undefined;
       return;
     }
 

--- a/src/webgl/Surface.js
+++ b/src/webgl/Surface.js
@@ -5,12 +5,13 @@ import getMouseOrTouch from '../utils/getMouseOrTouch.js';
 
 import { MOUSE, MOUSEDRAG, RESOLUTION, SURFACE_UNIFORMS } from './constants.js';
 
-function Surface(element, program, sdNode) {
+function Surface(element) {
   const canvas =
-    element instanceof HTMLCanvasElement
-      ? element
+    element.canvas instanceof HTMLCanvasElement
+      ? element.canvas
       : document.createElementNS('http://www.w3.org/1999/xhtml', 'canvas');
   const ctx2d = canvas.getContext('2d');
+  const program = element.program;
 
   const clickCallbacks = new Set();
   const ustate = cheapClone(SURFACE_UNIFORMS);
@@ -74,24 +75,18 @@ function Surface(element, program, sdNode) {
       newRect.right - newRect.width <=
         (window.innerWidth || document.documentElement.clientWidth);
 
-    const h =
-      sdNode.forcedHeight && sdNode.forcedHeight > 0
-        ? sdNode.forcedHeight
-        : newRect.height;
-    const w =
-      sdNode.forcedWidth && sdNode.forcedWidth > 0
-        ? sdNode.forcedWidth
-        : newRect.width;
+    const h = element.height > 0 ? element.height : newRect.height;
+    const w = element.width > 0 ? element.width : newRect.width;
 
-    if (w !== rect.width) {
+    if (w !== ustate[RESOLUTION].value[0]) {
       canvas.width = ustate[RESOLUTION].value[0] = w;
     }
 
-    if (h !== rect.height) {
+    if (h !== ustate[RESOLUTION].value[1]) {
       canvas.height = ustate[RESOLUTION].value[1] = h;
     }
 
-    rect = { width: canvas.width, height: canvas.height };
+    rect = newRect;
   }
 
   function render(
@@ -105,8 +100,8 @@ function Surface(element, program, sdNode) {
     tick();
     if (!visible || !program) return;
 
-    const width = rect.width || 0;
-    const height = rect.height || 0;
+    const width = ustate[RESOLUTION].value[0] || 0;
+    const height = ustate[RESOLUTION].value[1] || 0;
     updateRendererSize(width, height);
 
     program.render(width, height, [...ustateArray, ...ustate]);


### PR DESCRIPTION
Here is a quick follow up to #31 (cc: @nathanvogel, @SaFrMo).

I moved the force-width and force-height attributes from sd-node to the main shader-doodle component, since setting height/width on subsequent nodes at this point doesn't quite make sense (although I could see a use case in the future). I also renamed them to just width/height to feel a bit like an `<img/>` tag. I also removed the `resetSingleton` calls from #31 as they introduced a regression with multiple doodle and just in general they didn't feel like the right way to go about the problem (no hard feelings).  Let me know if this all looks ok to you and still serves you in the way that #31 did.