### PR TITLE
bugfix: video textures regression

### DIFF
--- a/src/utils/getSourceDimensions.js
+++ b/src/utils/getSourceDimensions.js
@@ -1,0 +1,8 @@
+export default function getSourceDimensions(source) {
+  if (!source) return [0, 0];
+
+  const tag = (source.tagName || '').toLowerCase();
+  if (tag === 'video') return [source.videoWidth, source.videoHeight];
+  if (tag === 'img') return [source.naturalWidth, source.naturalHeight];
+  return [source.width, source.height];
+}

--- a/src/webgl/Texture.js
+++ b/src/webgl/Texture.js
@@ -1,3 +1,5 @@
+import getSourceDimensions from '../utils/getSourceDimensions.js';
+
 const PIXEL = new Uint8Array([0, 0, 0, 255]);
 
 const isPow2 = value => !(value & (value - 1)) && !!value;
@@ -99,10 +101,9 @@ export default function Texture(gl, textureUnit, optsParam = {}) {
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
 
     if (pixels) {
-      if (pixels.width === 0 || pixels.height === 0) {
-        console.warn(
-          `Texture size is invalid ${pixels.width} x ${pixels.height}. Update is skipped;`
-        );
+      const [w, h] = getSourceDimensions(pixels);
+      if (w === 0 || h === 0) {
+        console.warn(`Texture size is invalid ${w} x ${h}. Update is skipped;`);
 
         return;
       }


### PR DESCRIPTION
fixes a regression introduced by #29 where videos early returned b/c
they didn't have a width/height, by instead using videoWidth/videoHeight

also switches to using naturalWidth/naturalHeight for images